### PR TITLE
Fix a bug in SimpleWorkloadDriver related with json parsing

### DIFF
--- a/org.spotter.ext.workload/src/org/spotter/ext/workload/simple/SimpleWorkloadDriver.java
+++ b/org.spotter.ext.workload/src/org/spotter/ext/workload/simple/SimpleWorkloadDriver.java
@@ -16,6 +16,7 @@
 package org.spotter.ext.workload.simple;
 
 import java.io.File;
+import java.net.MalformedURLException;
 import java.net.URL;
 import java.net.URLClassLoader;
 import java.util.Properties;
@@ -247,8 +248,13 @@ public class SimpleWorkloadDriver extends AbstractWorkloadAdapter {
 			urlClassLoader = new URLClassLoader(urls, this.getClass().getClassLoader());
 
 			vUserClass = urlClassLoader.loadClass(userScriptClassNAme);
-		} catch (Exception e) {
+		} catch (MalformedURLException e) {
 			throw new WorkloadException(e);
+		} catch (ClassNotFoundException e) {
+			// Cannot include ClassNotFoundException because it is not parsable
+			// as JSON string due to unrecognized field ("ex" instead of
+			// "exception")
+			throw new WorkloadException("Could not find specified class '" + e.getMessage() + "'");
 		}
 		return vUserClass;
 	}


### PR DESCRIPTION
This bug led to false "Finished diagnosis successfully" messages in the
UI if a ClassNotFoundException had been thrown (e.g. user configured
non-existing VU script class) during a failed diagnosis because this
class cannot be serialized and transmitted correctly using the rest
service.

The reason behind this is that the class ClassNotFoundException uses its
own field "ex" instead of "cause" of the super class Throwable. It has
for legacy reasons two methods to access this field, the old one
"getException()" and the new one "getCause()". Now when serializing an
object of this class, the jackson json processor struggles with the
field "ex" and throws an UnrecognizedPropertyException. Thus the
exception cannot be included in the tree and had to be replaced by an
according message instead.

Change-Id: I59057ae61296a95ddbc437b4b7aa61174c0ee70c
Signed-off-by: Denis Knoepfle <denis.knoepfle@sap.com>